### PR TITLE
Fix unpacking data

### DIFF
--- a/Marlin/i2cEncoder.cpp
+++ b/Marlin/i2cEncoder.cpp
@@ -335,18 +335,16 @@ long I2cEncoder::get_raw_count() {
     encoderCount.bval[index] = a;
     index += 1;
   }
-
+  //extract sign bit
+  bool sign = (encoderCount.bval[2] & B00100000); 
   //extract the magnetic strength
-  magneticStrength = (byte)(0x3 & (encoderCount.val >> 22));
-
-  //Clear the sign bit, just in case
-  encoderCount.val &= ~((long)1 << 31);
-
-  //extract the packed sign bit from bit 21 to bit 31
-  encoderCount.val |= ((((long)1<<21) & encoderCount.val) << 10);
-
-  //clear the packed bits, they're not part of the encoder position long
-  encoderCount.val &= ~((long)7 << 21);
+  magneticStrength = (B00000011 & (encoderCount.bval[2] >> 6));
+  //set all upper bits to the sign value to overwrite magneticStrength
+  if (sign) { 
+    encoderCount.val = (encoderCount.val | 0xFFC00000); 
+  }else{
+    encoderCount.val = (encoderCount.val & 0x003FFFFF); 
+  }
 
   if(get_inverted()) {
     return -encoderCount.val;


### PR DESCRIPTION
This simplifies the unpacking of the data and converting it into a long and clarifies the bitwise operations taking place by using Byte and Hex data type constants